### PR TITLE
Tick timeout detection & cleanup

### DIFF
--- a/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
+++ b/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
@@ -330,9 +330,11 @@ public class ASMHookTerminator {
 		} else {
 			// phaser.arriveAndAwaitAdvance();
 			try {
+				// arrive and wait for up to 1 second (20 ticks)
 				phaser.awaitAdvanceInterruptibly(phaser.arrive(), 1, TimeUnit.SECONDS);
 			} catch (InterruptedException e) {
 				LOGGER.fatal("Waiting for ticks interrupted: ", e);
+				phaser.awaitAdvance(phaser.getPhase()); // wait for this tick to complete
 			} catch (TimeoutException e) {
 				LOGGER.error("This tick has taken longer than 1 second, investigating...");
 				LOGGER.error("Current stuck tasks:");

--- a/src/main/java/org/jmt/mcmt/asmdest/ChunkRepairHookTerminator.java
+++ b/src/main/java/org/jmt/mcmt/asmdest/ChunkRepairHookTerminator.java
@@ -23,14 +23,13 @@ import net.minecraft.world.server.ChunkHolder;
 import net.minecraft.world.server.ChunkHolder.IChunkLoadingError;
 import net.minecraft.world.server.ServerChunkProvider;
 
-// TODO Should be renamed ChunkRepairHookTerminator (Note requres coremod edit)
 /**
- * Handles chunk forcing in scenarios where world corruption has occured
+ * Handles chunk forcing in scenarios where world corruption has occurred
  * 
  * @author jediminer543
  *
  */
-public class DebugHookTerminator {
+public class ChunkRepairHookTerminator {
 	
 	private static final Logger LOGGER = LogManager.getLogger();
 	
@@ -40,20 +39,28 @@ public class DebugHookTerminator {
 		return bypassLoadTarget;
 	}
 		
-	public static void chunkLoadDrive(ServerChunkProvider.ChunkExecutor executor, BooleanSupplier isDone, ServerChunkProvider scp, 
-			CompletableFuture<Either<IChunk, IChunkLoadingError>> completableFuture, long chunkpos) {
+	public static void chunkLoadDrive(
+			ServerChunkProvider.ChunkExecutor executor,
+			BooleanSupplier isDone,
+			ServerChunkProvider scp, 
+			CompletableFuture<Either<IChunk, IChunkLoadingError>> completableFuture, 
+			long chunkpos) {
+		
 		if (!GeneralConfig.enableChunkTimeout) {
 			bypassLoadTarget = false;
 			executor.driveUntil(isDone);
 			return;
 		}
+		
 		int failcount = 0;
 		while (!isDone.getAsBoolean()) {
+			
 			if (!executor.driveOne()) {
+				
 				if(isDone.getAsBoolean()) {
-					break;
+					break; // Nothing more to execute
 				}
-				// Nothing more to execute
+				
 				if (failcount++ < GeneralConfig.timeoutCount) {
 					Thread.yield();
 					LockSupport.parkNanos("THE END IS ~~NEVER~~ LOADING", 100000L);

--- a/src/main/java/org/jmt/mcmt/commands/ConfigCommand.java
+++ b/src/main/java/org/jmt/mcmt/commands/ConfigCommand.java
@@ -182,7 +182,7 @@ public class ConfigCommand {
 						BlockPos bp = ((BlockRayTraceResult)rtr).getPos();
 						TileEntity te = cmdCtx.getSource().getWorld().getTileEntity(bp);
 						if (te != null && te instanceof ITickableTileEntity) {
-							boolean willSerial = ASMHookTerminator.filterTE((ITickableTileEntity)te);
+							boolean willSerial = ASMHookTerminator.filterTickableEntity((ITickableTileEntity)te);
 							message = new StringTextComponent("That TE " + (!willSerial ? "will" : "will not") + " tick fully parallelised");
 							cmdCtx.getSource().sendFeedback(message, true);
 							return 1;

--- a/src/main/java/org/jmt/mcmt/config/GeneralConfig.java
+++ b/src/main/java/org/jmt/mcmt/config/GeneralConfig.java
@@ -77,6 +77,8 @@ public class GeneralConfig {
 	public static boolean opsTracing;
 	public static int logcap;
 	
+	public static boolean continueAfterStuckTick;
+	
 	//Forge stuff
 	public static final GeneralConfigTemplate GENERAL;
 	public static final ForgeConfigSpec GENERAL_SPEC;
@@ -150,6 +152,8 @@ public class GeneralConfig {
 		opsTracing = GENERAL.opsTracing.get();
 		logcap = GENERAL.logcap.get();
 		
+		continueAfterStuckTick = GENERAL.continueAfterStuckTick.get();
+		
 		teWhiteList = ConcurrentHashMap.newKeySet();//new HashSet<Class<?>>();
 		teUnfoundWhiteList = new ArrayList<String>();
 		GENERAL.teWhiteList.get().forEach(str -> {
@@ -197,6 +201,8 @@ public class GeneralConfig {
 		GENERAL.opsTracing.set(opsTracing);
 		GENERAL.logcap.set(logcap);
 		
+		GENERAL.continueAfterStuckTick.set(continueAfterStuckTick);
+		
 		GENERAL.teWhiteList.get().clear();
 		GENERAL.teWhiteList.get().addAll(teUnfoundWhiteList);
 		GENERAL.teWhiteList.get().addAll(teWhiteList.stream().map(clz -> clz.getName()).collect(Collectors.toList()));
@@ -234,6 +240,8 @@ public class GeneralConfig {
 		
 		public final BooleanValue opsTracing;
 		public final IntValue logcap;
+		
+		public final BooleanValue continueAfterStuckTick;
 		
 		public GeneralConfigTemplate(ForgeConfigSpec.Builder builder) {
 			builder.push("general");
@@ -308,7 +316,7 @@ public class GeneralConfig {
 					.comment("Attempts to re-load timed out chunks; Seems to work")
 					.define("enableTimeoutReload", false);
 			timeoutCount = builder
-					.comment("Ammount of workless iterations to wait before declaring a chunk load attempt as timed out\n"
+					.comment("Amount of workless iterations to wait before declaring a chunk load attempt as timed out\n"
 							+"This is in ~100us itterations (plus minus yield time) so timeout >= timeoutCount*100us")
 					.defineInRange("timeoutCount", 5000, 500, 500000);
 			builder.pop();
@@ -323,6 +331,11 @@ public class GeneralConfig {
 			logcap = builder
 					.comment("Maximum time between MCMT presence alerts in 10ms steps")
 					.defineInRange("logcap", 720000, 15000, Integer.MAX_VALUE);
+			builder.pop();
+			builder.push("continueAfterStuckTick");
+			builder.comment("Allows continuation after a stuck tick. "
+					+ "This is HIGHLY unstable, so don't enable it unless you know what you're doing and have backups.");
+			continueAfterStuckTick = builder.define("continueAfterStuckTick", false);
 		}
 
 	}

--- a/src/main/java/org/jmt/mcmt/paralelised/ConcurrentArrayList.java
+++ b/src/main/java/org/jmt/mcmt/paralelised/ConcurrentArrayList.java
@@ -1,0 +1,458 @@
+package org.jmt.mcmt.paralelised;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.ListIterator;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * @author Hunter
+ *
+ * @param <E> the type of elements in this list
+ */
+public class ConcurrentArrayList<E> extends ArrayList<E> {
+	private static final long serialVersionUID = -6104897338204207229L;
+	private ReadWriteLock lock = new ReentrantReadWriteLock();
+	
+	public ConcurrentArrayList() {
+		super();
+	}
+	
+	public ConcurrentArrayList(Collection<? extends E> arg0) {
+		super(arg0);
+	}
+	
+	public ConcurrentArrayList(int capacity) {
+		super(capacity);
+	}
+	
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		lock.readLock().lock();
+		try {
+			return super.containsAll(c);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean contains(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.contains(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.equals(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public void forEach(Consumer<? super E> action) {
+		lock.readLock().lock();
+		try {
+			super.forEach(action);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public E get(int index) {
+		lock.readLock().lock();
+		try {
+			return super.get(index);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public int hashCode() {
+		lock.readLock().lock();
+		try {
+			return super.hashCode();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public int indexOf(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.indexOf(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean isEmpty() {
+		return super.isEmpty(); // Immediate return doesn't require a read lock
+	}
+	
+	@Override
+	public int lastIndexOf(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.lastIndexOf(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public int size() {
+		lock.readLock().lock();
+		try {
+			return super.size();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public Object[] toArray() {
+		lock.readLock().lock();
+		try {
+			return super.toArray();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public <T> T[] toArray(IntFunction<T[]> generator) {
+		lock.readLock().lock();
+		try {
+			return super.toArray(generator);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public <T> T[] toArray(T[] a) {
+		lock.readLock().lock();
+		try {
+			return super.toArray(a);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public String toString() {
+		lock.readLock().lock();
+		try {
+			return super.toString();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean add(E e) {
+		lock.writeLock().lock();
+		try {
+			return super.add(e);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void add(int index, E element) {
+		lock.writeLock().lock();
+		try {
+			super.add(index, element);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean addAll(Collection<? extends E> c) {
+		lock.writeLock().lock();
+		try {
+			return super.addAll(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean addAll(int index, Collection<? extends E> c) {
+		lock.writeLock().lock();
+		try {
+			return super.addAll(index, c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void clear() {
+		lock.writeLock().lock();
+		try {
+			super.clear();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public Object clone() {
+		lock.readLock().lock();
+		try {
+			return super.clone();
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	@Override
+	public void ensureCapacity(int minCapacity) {
+		lock.writeLock().lock();
+		try {
+			super.ensureCapacity(minCapacity);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public E remove(int index) {
+		lock.writeLock().lock();
+		try {
+			return super.remove(index);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void trimToSize() {
+		lock.writeLock().lock();
+		try {
+			super.trimToSize();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean remove(Object o) {
+		lock.writeLock().lock();
+		try {
+			return super.remove(o);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		lock.writeLock().lock();
+		try {
+			return super.removeAll(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean removeIf(Predicate<? super E> filter) {
+		lock.writeLock().lock();
+		try {
+			return super.removeIf(filter);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	protected void removeRange(int fromIndex, int toIndex) {
+		lock.writeLock().lock();
+		try {
+			super.removeRange(fromIndex, toIndex);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void replaceAll(UnaryOperator<E> operator) {
+		lock.writeLock().lock();
+		try {
+			super.replaceAll(operator);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		lock.writeLock().lock();
+		try {
+			return super.retainAll(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public E set(int index, E element) {
+		lock.writeLock().lock();
+		try {
+			return super.set(index, element);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void sort(Comparator<? super E> c) {
+		lock.writeLock().lock();
+		try {
+			super.sort(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public Iterator<E> iterator() {
+		return new CopiedIterator(this);
+	}
+	
+	@Override
+	public ListIterator<E> listIterator() {
+		return new CopiedListIterator(this);
+	}
+	
+	@Override
+	public ListIterator<E> listIterator(int index) {
+		return new CopiedListIterator(this, index);
+	}
+	
+	/**
+	 * Creates a snapshot of the Collection to iterate over. Useful for concurrent access to the entirety of a Collection.
+	 * <p>
+	 * Caveats: <p>
+	 * Creates a copy of the Collection as an array, so uses more memory
+	 * (<a href="https://www.baeldung.com/java-size-of-object#1-objects-references-and-wrapper-classes">but not 100% more, just for object references</a>)
+	 * <p>
+	 * Any changes to the objects in the Iterator will be reflected in the originating Collection.
+	 *   
+	 * @author hunterh 
+	 */
+	private class CopiedIterator implements Iterator<E> {
+		private Object[] internal;
+		private int pointer;
+		
+		public CopiedIterator(Collection<? extends E> c) {
+			this.pointer = 0;
+			this.internal = c.toArray();
+		}
+
+		@Override
+		public boolean hasNext() {
+			return internal.length > pointer;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public E next() {
+			return (E) this.internal[this.pointer++];
+		}
+	}
+	
+	/**
+	 * Creates a snapshot of the Collection to iterate over. Useful for concurrent access to the entirety of a Collection.
+	 * <p>
+	 * Caveats: <p>
+	 * Creates a copy of the Collection as a {@link ConcurrentArrayList}, so uses more memory
+	 * (<a href="https://www.baeldung.com/java-size-of-object#1-objects-references-and-wrapper-classes">but not 100% more, just for object references</a>)
+	 * <p>
+	 * Any changes to the objects in the Iterator will be reflected in the originating Collection.
+	 *   
+	 * @author hunterh 
+	 */
+	private class CopiedListIterator implements ListIterator<E> {
+		private ConcurrentArrayList<E> backing;
+		private int pointer;
+		
+		public CopiedListIterator(Collection<? extends E> data) {
+			backing = new ConcurrentArrayList<>(data);
+			pointer = 0;
+		}
+		
+		public CopiedListIterator(Collection<? extends E> data, int start) {
+			backing = new ConcurrentArrayList<>(data);
+			pointer = start;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return backing.size() > pointer;
+		}
+
+		@Override
+		public E next() {
+			return backing.get(pointer++);
+		}
+
+		@Override
+		public boolean hasPrevious() {
+			return pointer > 0;
+		}
+
+		@Override
+		public E previous() {
+			return backing.get(pointer--);
+		}
+
+		@Override
+		public int nextIndex() {
+			return hasNext() ? pointer + 1 : backing.size();
+		}
+
+		@Override
+		public int previousIndex() {
+			return hasPrevious() ? pointer - 1: -1;
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException("CopiedListIterator does not support remove()");
+		}
+
+		@Override
+		public void set(E e) {
+			throw new UnsupportedOperationException("CopiedListIterator does not support set()");
+		}
+
+		@Override
+		public void add(E e) {
+			throw new UnsupportedOperationException("CopiedListIterator does not support add()");
+		}
+	}
+}

--- a/src/main/resources/trans/debug/SCPDriveDebug.js
+++ b/src/main/resources/trans/debug/SCPDriveDebug.js
@@ -53,7 +53,7 @@ function initializeCoreMod() {
         		il.add(new VarInsnNode(opcodes.ALOAD, 8));
         		il.add(new VarInsnNode(opcodes.LLOAD, 6));
         		il.add(new MethodInsnNode(opcodes.INVOKESTATIC, 
-        				"org/jmt/mcmt/asmdest/DebugHookTerminator", "chunkLoadDrive",
+        				"org/jmt/mcmt/asmdest/ChunkRepairHookTerminator", "chunkLoadDrive",
         				"(Lnet/minecraft/world/server/ServerChunkProvider$ChunkExecutor;Ljava/util/function/BooleanSupplier;Lnet/minecraft/world/server/ServerChunkProvider;Ljava/util/concurrent/CompletableFuture;J)V"        				,false));
         		il.add(new JumpInsnNode(opcodes.GOTO, skipTarget));
         		
@@ -114,7 +114,7 @@ function initializeCoreMod() {
         		
         		var il = new InsnList();
         		il.add(new MethodInsnNode(opcodes.INVOKESTATIC, 
-        				"org/jmt/mcmt/asmdest/DebugHookTerminator", "isBypassLoadTarget",
+        				"org/jmt/mcmt/asmdest/ChunkRepairHookTerminator", "isBypassLoadTarget",
         				"()Z"
         				,false));
         		il.add(new JumpInsnNode(opcodes.IFNE, labelTgt));
@@ -175,7 +175,7 @@ function initializeCoreMod() {
         		var il = new InsnList();
 				//il.add(new InsnNode(opcodes.DUP));
         		//il.add(new MethodInsnNode(opcodes.INVOKESTATIC, 
-        		//		"org/jmt/mcmt/asmdest/DebugHookTerminator", "checkNull",
+        		//		"org/jmt/mcmt/asmdest/ChunkRepairHookTerminator", "checkNull",
         		//		"(Ljava/lang/Object;)V", 
 				//		false));
         		

--- a/src/syncfu/java/org/jmt/mcmt/modlauncher/DevModeEnabler.java
+++ b/src/syncfu/java/org/jmt/mcmt/modlauncher/DevModeEnabler.java
@@ -24,6 +24,7 @@ public class DevModeEnabler implements ITransformer<ClassNode> {
 
 	
 	private static final Logger LOGGER = LogManager.getLogger();
+	@SuppressWarnings("unused")
 	private static final Marker M_LOCATOR = MarkerManager.getMarker("LOCATE");
 	private boolean isActive = true;
 	

--- a/src/syncfu/java/org/jmt/mcmt/modlauncher/FastUtilTransformerService.java
+++ b/src/syncfu/java/org/jmt/mcmt/modlauncher/FastUtilTransformerService.java
@@ -6,7 +6,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;


### PR DESCRIPTION
Added a sort of "tick timeout detection" that will help diagnose issues where ticks take too long/get stuck, along with a config option to force-continue after the tick gets stuck. Fixed a small issue with the boolean logic used to disable world post-tick multithreading, as well as refactor/clean up some formatting to help newcomers understand whats going on a little bit better. 