### PR TITLE
Phase out Phaser

### DIFF
--- a/src/main/java/org/jmt/mcmt/MCMT.java
+++ b/src/main/java/org/jmt/mcmt/MCMT.java
@@ -120,6 +120,12 @@ public class MCMT
     public static void time(Runnable r) {
     	Instant start = Instant.now();
     	r.run();
-    	LOGGER.info("Task took " + Instant.now().minusMillis(start.toEpochMilli()).toEpochMilli() + " ms.");
+    	LOGGER.info("Task finished, took " + Instant.now().minusMillis(start.toEpochMilli()).toEpochMilli() + " ms.");
+    }
+    
+    public static void time(Runnable r, String taskName) {
+    	Instant start = Instant.now();
+    	r.run();
+    	LOGGER.info(taskName + " finished in " + Instant.now().minusMillis(start.toEpochMilli()).toEpochMilli() + " ms.");
     }
 }

--- a/src/main/java/org/jmt/mcmt/MCMT.java
+++ b/src/main/java/org/jmt/mcmt/MCMT.java
@@ -1,5 +1,6 @@
 package org.jmt.mcmt;
 
+import java.time.Instant;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -114,5 +115,11 @@ public class MCMT
     	public static void registerEntities(RegistryEvent.Register<EntityType<?>> e) {
 
     	}
+    }
+    
+    public static void time(Runnable r) {
+    	Instant start = Instant.now();
+    	r.run();
+    	LOGGER.info("Task took " + Instant.now().minusMillis(start.toEpochMilli()).toEpochMilli() + " ms.");
     }
 }

--- a/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
+++ b/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
@@ -212,9 +212,9 @@ public class ASMHookTerminator {
 		} else {
 			String taskName =  "WorldTick: " + serverworld.toString() + "@" + serverworld.hashCode();
 			execute(taskName, () -> {
-				serverworld.tick(hasTimeLeft);
-				if (!GeneralConfig.disableWorldPostTick) {
-					exec.execute(() -> {
+				MCMT.time(() -> {
+					serverworld.tick(hasTimeLeft);
+					if (!GeneralConfig.disableWorldPostTick) {
 						//ForkJoinPool.managedBlock(
 						//		new RunnableManagedBlocker(() ->  { 
 						synchronized (net.minecraftforge.fml.hooks.BasicEventHooks.class) {
@@ -223,10 +223,12 @@ public class ASMHookTerminator {
 						//		}));
 						//} catch (InterruptedException e) {
 						//	e.printStackTrace();
-					});
-				} else {
-					net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(serverworld);
-				}
+					} else {
+						net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(serverworld);
+					}
+				});
+				LOGGER.info("Completed " + taskName);
+				worldExecutionStack.remove(taskName);
 			}, worldExecutionStack);
 		}
 	}

--- a/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
+++ b/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
@@ -330,9 +330,11 @@ public class ASMHookTerminator {
 		} else {
 			// phaser.arriveAndAwaitAdvance();
 			try {
+				// arrive and wait for up to 1 second (20 ticks)
 				phaser.awaitAdvanceInterruptibly(phaser.arrive(), 1, TimeUnit.SECONDS);
 			} catch (InterruptedException e) {
 				LOGGER.fatal("Waiting for ticks interrupted: ", e);
+				phaser.awaitAdvance(phaser.getPhase()); // wait for this tick to complete
 			} catch (TimeoutException e) {
 				LOGGER.error("This tick has taken longer than 1 second, investigating...");
 				LOGGER.error("Current stuck tasks:");

--- a/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
+++ b/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
@@ -112,7 +112,7 @@ public class ASMHookTerminator {
 		return isThreadPooled("MCMT", Thread.currentThread());
 	}
 
-	// create a CompletableFuture, run it, and add it to the execution stack
+	// Add a Runnable to the execution stack
 	private static void execute(String taskName, Runnable task, ConcurrentHashMap<String, Runnable> stack) {
 		synchronized (stack) {
 			// ensure there is no accidental key collision
@@ -296,12 +296,7 @@ public class ASMHookTerminator {
 			}, SerDesHookTypes.TETick);
 		} else {
 			execute(taskName, () -> {
-				try {
-					tte.tick();
-				} catch (Exception e) {
-					System.err.println("Exception ticking TE at " + ((TileEntity) tte).getPos());
-					e.printStackTrace();
-				}
+				tte.tick();
 			}, entityExecutionStack);
 		}
 	}

--- a/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
+++ b/src/main/java/org/jmt/mcmt/asmdest/ASMHookTerminator.java
@@ -1,16 +1,18 @@
 package org.jmt.mcmt.asmdest;
 
+import java.time.Instant;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -59,7 +61,8 @@ public class ASMHookTerminator {
 
 	private static final Logger LOGGER = LogManager.getLogger();
 
-	static Phaser phaser;
+	//	static Phaser phaser;
+	static ConcurrentHashMap<String, CompletableFuture<Void>> executionStack = new ConcurrentHashMap<>();
 	static ExecutorService exec;
 	static MinecraftServer mcServer;
 	static AtomicBoolean isTicking = new AtomicBoolean();
@@ -99,9 +102,6 @@ public class ASMHookTerminator {
 	public static AtomicInteger currentTEs = new AtomicInteger();
 	public static AtomicInteger currentEnvs = new AtomicInteger();
 
-	//Operation logging
-	public static Set<String> currentTasks = ConcurrentHashMap.newKeySet(); 
-
 
 	public static void regThread(String poolName, Thread thread) {
 		mcThreadTracker.computeIfAbsent(poolName, s -> ConcurrentHashMap.newKeySet()).add(thread);
@@ -115,27 +115,66 @@ public class ASMHookTerminator {
 		return isThreadPooled("MCMT", Thread.currentThread());
 	}
 
-	public static void preTick(MinecraftServer server) {
-		// enable phaser reuse
-//		if (phaser != null) {
-//			LOGGER.warn("Multiple servers?");
-//			return;
-//		} else {
-//			isTicking.set(true);
-//			phaser = new Phaser();
-//			phaser.register();
-//			mcServer = server;
-//			StatsCommand.setServer(mcServer);
-//		}
-		// if the phaser does not exist or is terminated, recreate it
-		if (phaser == null || phaser.isTerminated()) {
-			phaser = new Phaser();
+	// create a CompletableFuture, run it, and add it to the execution stack
+	private static void execute(String taskName, Runnable task) {
+		// ensure there is no accidental key collision
+		while (executionStack.containsKey(taskName)) taskName = taskName + "+";
+		String finalTaskName = taskName;
+		// add a CompletableFuture to the execution stack that runs the given task, then removes itself when done
+		executionStack.put(finalTaskName, CompletableFuture.runAsync(task, exec).thenRun(() -> {executionStack.remove(finalTaskName);}));
+	}
+
+	private static void awaitCompletion() {
+		Instant before = Instant.now();
+		// convert all outstanding ticks to one CompletableFuture to wait on
+		CompletableFuture<Void> allTicks = CompletableFuture.allOf(executionStack.values().toArray(new CompletableFuture[executionStack.size()]));
+		try {
+			// wait on all executing ticks for up to 1 second (20 ticks)
+			allTicks.get(1, TimeUnit.SECONDS);
+			LOGGER.info(executionStack.size());
+		} catch (TimeoutException e) {
+			LOGGER.error("This tick has taken longer than 1 second, investigating...");
+			LOGGER.error("Current stuck tasks:");
+			StringJoiner sj = new StringJoiner(", ", "[ ", " ]");
+			for (String taskName : executionStack.keySet()) sj.add(taskName);
+			LOGGER.error(sj.toString());
+
+			if (GeneralConfig.continueAfterStuckTick) {
+				LOGGER.fatal("CONTINUING AFTER STUCK TICK! I REALLY hope you have backups...");
+				allTicks.cancel(true); // cancel combined CompletableFuture
+				executionStack.clear(); // empty the execution stack for another go-around
+			} else {
+				LOGGER.error("Continuing to wait for tick to complete... (don't hold your breath)");
+				try {
+					allTicks.get(); // wait for this tick to complete (but if we're here, it probably won't)
+				} catch (InterruptedException | ExecutionException e1) {
+					LOGGER.fatal("Failed to wait for tick: ", e1);
+				} 
+			}
+		} catch (ExecutionException | InterruptedException e) {
+			LOGGER.fatal("Tick execution failed: ", e);
+			allTicks.cancel(true);
+			executionStack.clear(); // clear execution stack without prompt, we're in uncharted waters anyways
 		}
-		// set up for the next tick
+
+		// debug data for how long the tick took
+		LOGGER.info("This tick took " + Instant.now().minusMillis(before.toEpochMilli()).toEpochMilli() + " ms.");
+
+		if (executionStack.size() > 0) {
+			LOGGER.fatal("Execution stack was not empty before continuing to next tick! " + executionStack.size());
+			
+			StringJoiner sj = new StringJoiner(", ", "[ ", " ]");
+			for (String taskName : executionStack.keySet()) sj.add(taskName);
+			LOGGER.fatal(sj.toString());
+			
+			executionStack.clear();
+		}
+	}
+
+	public static void preTick(MinecraftServer server) {
 		isTicking.set(true);
-		phaser.register();
 		mcServer = server;
-		StatsCommand.setServer(server);
+		StatsCommand.setServer(mcServer);
 	}
 
 	public static void callTick(ServerWorld serverworld, BooleanSupplier hasTimeLeft, MinecraftServer server) {
@@ -149,7 +188,7 @@ public class ASMHookTerminator {
 			}
 			return;
 		}
-		
+
 		if (mcServer != server) {
 			LOGGER.warn("Multiple servers?");
 			GeneralConfig.disabled = true;
@@ -157,44 +196,30 @@ public class ASMHookTerminator {
 			net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(serverworld);
 			return;
 		} else {
-			String taskName = null;
-			if (GeneralConfig.opsTracing) {
-				taskName =  "WorldTick: " + serverworld.toString() + "@" + serverworld.hashCode();
-				currentTasks.add(taskName);
-			}
-			String finalTaskName = taskName;
-			phaser.register();
-			exec.execute(() -> {
+			String taskName =  "WorldTick: " + serverworld.toString() + "@" + serverworld.hashCode();
+			execute(taskName, () -> {
 				try {
 					currentWorlds.incrementAndGet();
 					serverworld.tick(hasTimeLeft);
 					if (!GeneralConfig.disableWorldPostTick) {
-						phaser.register();
 						exec.execute(() -> {
-							try {
-								//ForkJoinPool.managedBlock(
-								//		new RunnableManagedBlocker(() ->  { 
-								synchronized (net.minecraftforge.fml.hooks.BasicEventHooks.class) {
-									net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(serverworld);
-								}
-								//		}));
-								//} catch (InterruptedException e) {
-								//	e.printStackTrace();
-							} finally {
-								phaser.arriveAndDeregister();
+							//ForkJoinPool.managedBlock(
+							//		new RunnableManagedBlocker(() ->  { 
+							synchronized (net.minecraftforge.fml.hooks.BasicEventHooks.class) {
+								net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(serverworld);
 							}
+							//		}));
+							//} catch (InterruptedException e) {
+							//	e.printStackTrace();
 						});
 					} else {
 						net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(serverworld);
 					}
 				} finally {
-					phaser.arriveAndDeregister();
 					currentWorlds.decrementAndGet();
-					if (GeneralConfig.opsTracing) currentTasks.remove(finalTaskName);
 				}
 			});
 		}
-
 	}
 
 	public static void callEntityTick(Entity entityIn, ServerWorld serverworld) {
@@ -202,21 +227,13 @@ public class ASMHookTerminator {
 			entityIn.tick();
 			return;
 		}
-		String taskName = null;
-		if (GeneralConfig.opsTracing) {
-			taskName = "EntityTick: " + entityIn.toString() + "@" + entityIn.hashCode();
-			currentTasks.add(taskName);
-		}
-		String finalTaskName = taskName;
-		phaser.register();
-		exec.execute(() -> {
+		String taskName = "EntityTick: " + entityIn.toString() + "@" + entityIn.hashCode();
+		execute(taskName, () -> {
 			try {
 				currentEnts.incrementAndGet();
 				entityIn.tick();
 			} finally {
 				currentEnts.decrementAndGet();
-				phaser.arriveAndDeregister();
-				if (GeneralConfig.opsTracing) currentTasks.remove(finalTaskName);
 			}
 		});
 	}
@@ -226,21 +243,13 @@ public class ASMHookTerminator {
 			world.tickEnvironment(chunk, k);
 			return;
 		}
-		String taskName = null;
-		if (GeneralConfig.opsTracing) {
-			taskName = "EnvTick: " + chunk.toString() + "@" + chunk.hashCode();
-			currentTasks.add(taskName);
-		}
-		String finalTaskName = taskName;
-		phaser.register();
-		exec.execute(() -> {
+		String taskName = "EnvTick: " + chunk.toString() + "@" + chunk.hashCode();
+		execute(taskName, () -> {
 			try {
 				currentEnvs.incrementAndGet();
 				world.tickEnvironment(chunk, k);
 			} finally {
 				currentEnvs.decrementAndGet();
-				phaser.arriveAndDeregister();
-				if (GeneralConfig.opsTracing) currentTasks.remove(finalTaskName);
 			}
 		});
 	}
@@ -269,13 +278,8 @@ public class ASMHookTerminator {
 			return;
 		}
 		String taskName = null;
-		if (GeneralConfig.opsTracing) {
-			taskName = "TETick: " + tte.toString()  + "@" + tte.hashCode();
-			currentTasks.add(taskName);
-		}
-		phaser.register();
-		String finalTaskName = taskName;
-		exec.execute(() -> {
+		taskName = "TETick: " + tte.toString()  + "@" + tte.hashCode();
+		execute(taskName, () -> {
 			try {
 				final boolean doLock = filterTickableEntity(tte);
 				if (doLock) {
@@ -298,8 +302,6 @@ public class ASMHookTerminator {
 				e.printStackTrace();
 			} finally {
 				currentTEs.decrementAndGet();
-				phaser.arriveAndDeregister();
-				if (GeneralConfig.opsTracing) currentTasks.remove(finalTaskName);
 			}
 		});
 	}
@@ -328,31 +330,7 @@ public class ASMHookTerminator {
 			LOGGER.warn("Multiple servers?");
 			return;
 		} else {
-			// phaser.arriveAndAwaitAdvance();
-			try {
-				// arrive and wait for up to 1 second (20 ticks)
-				phaser.awaitAdvanceInterruptibly(phaser.arrive(), 1, TimeUnit.SECONDS);
-			} catch (InterruptedException e) {
-				LOGGER.fatal("Waiting for ticks interrupted: ", e);
-				phaser.awaitAdvance(phaser.getPhase()); // wait for this tick to complete
-			} catch (TimeoutException e) {
-				LOGGER.error("This tick has taken longer than 1 second, investigating...");
-				LOGGER.error("Current stuck tasks:");
-				StringJoiner sj = new StringJoiner(", ", "[ ", " ]");
-				for (String taskName : currentTasks) sj.add(taskName);
-				LOGGER.error(sj.toString());
-				
-				if (GeneralConfig.continueAfterStuckTick) {
-					LOGGER.fatal("CONTINUING AFTER STUCK TICK! I REALLY hope you have backups...");
-					phaser.forceTermination(); // forces termination of phaser
-				} else {
-					LOGGER.error("Continuing to wait for tick to complete... (don't hold your breath)");
-					phaser.awaitAdvance(phaser.getPhase()); // wait for this tick to complete (but if we're here, it probably won't)
-				}
-			}
-			isTicking.set(false);
-			// probably faster if we just use the same phaser
-			// phaser = null;
+			awaitCompletion();
 		}
 	}
 
@@ -376,7 +354,7 @@ public class ASMHookTerminator {
 		//TODO expand on TE settings
 		if (GeneralConfig.opsTracing) {
 			confInfo.append("\t\t"); confInfo.append("-- Running Operations Begin -- "); confInfo.append("\n");
-			for (String s : currentTasks) {
+			for (String s : executionStack.keySet()) {
 				confInfo.append("\t\t"); confInfo.append("\t"); confInfo.append(s); confInfo.append("\n");
 			}
 			confInfo.append("\t\t"); confInfo.append("-- Running Operations End -- "); confInfo.append("\n");
@@ -392,7 +370,7 @@ public class ASMHookTerminator {
 		LOGGER.debug("FixSTL Called");
 		stl.pendingTickListEntriesTreeSet.addAll(stl.pendingTickListEntriesHashSet);
 	}
-	
+
 	//Below is debug code for science reasons
 	/*
 	 * 	static Random debugRand = new Random();
@@ -406,6 +384,6 @@ public class ASMHookTerminator {
 		}
 	}
 	//End Debug Section
-	*/
+	 */
 }
 

--- a/src/main/java/org/jmt/mcmt/asmdest/ChunkRepairHookTerminator.java
+++ b/src/main/java/org/jmt/mcmt/asmdest/ChunkRepairHookTerminator.java
@@ -23,14 +23,13 @@ import net.minecraft.world.server.ChunkHolder;
 import net.minecraft.world.server.ChunkHolder.IChunkLoadingError;
 import net.minecraft.world.server.ServerChunkProvider;
 
-// TODO Should be renamed ChunkRepairHookTerminator (Note requres coremod edit)
 /**
- * Handles chunk forcing in scenarios where world corruption has occured
+ * Handles chunk forcing in scenarios where world corruption has occurred
  * 
  * @author jediminer543
  *
  */
-public class DebugHookTerminator {
+public class ChunkRepairHookTerminator {
 	
 	private static final Logger LOGGER = LogManager.getLogger();
 	
@@ -40,20 +39,28 @@ public class DebugHookTerminator {
 		return bypassLoadTarget;
 	}
 		
-	public static void chunkLoadDrive(ServerChunkProvider.ChunkExecutor executor, BooleanSupplier isDone, ServerChunkProvider scp, 
-			CompletableFuture<Either<IChunk, IChunkLoadingError>> completableFuture, long chunkpos) {
+	public static void chunkLoadDrive(
+			ServerChunkProvider.ChunkExecutor executor,
+			BooleanSupplier isDone,
+			ServerChunkProvider scp, 
+			CompletableFuture<Either<IChunk, IChunkLoadingError>> completableFuture, 
+			long chunkpos) {
+		
 		if (!GeneralConfig.enableChunkTimeout) {
 			bypassLoadTarget = false;
 			executor.driveUntil(isDone);
 			return;
 		}
+		
 		int failcount = 0;
 		while (!isDone.getAsBoolean()) {
+			
 			if (!executor.driveOne()) {
+				
 				if(isDone.getAsBoolean()) {
-					break;
+					break; // Nothing more to execute
 				}
-				// Nothing more to execute
+				
 				if (failcount++ < GeneralConfig.timeoutCount) {
 					Thread.yield();
 					LockSupport.parkNanos("THE END IS ~~NEVER~~ LOADING", 100000L);

--- a/src/main/java/org/jmt/mcmt/commands/ConfigCommand.java
+++ b/src/main/java/org/jmt/mcmt/commands/ConfigCommand.java
@@ -182,7 +182,7 @@ public class ConfigCommand {
 						BlockPos bp = ((BlockRayTraceResult)rtr).getPos();
 						TileEntity te = cmdCtx.getSource().getWorld().getTileEntity(bp);
 						if (te != null && te instanceof ITickableTileEntity) {
-							boolean willSerial = ASMHookTerminator.filterTE((ITickableTileEntity)te);
+							boolean willSerial = ASMHookTerminator.filterTickableEntity((ITickableTileEntity)te);
 							message = new StringTextComponent("That TE " + (!willSerial ? "will" : "will not") + " tick fully parallelised");
 							cmdCtx.getSource().sendFeedback(message, true);
 							return 1;

--- a/src/main/java/org/jmt/mcmt/commands/StatsCommand.java
+++ b/src/main/java/org/jmt/mcmt/commands/StatsCommand.java
@@ -147,17 +147,13 @@ public class StatsCommand {
 								maxThreads[currentPos] = 0;
 							}
 							int total = 0;
-							int worlds = ASMHookTerminator.currentWorlds.get();
+							int worldTicks = ASMHookTerminator.worldExecutionStack.size();
 							maxWorlds[currentPos] = Math.max(maxWorlds[currentPos],
-									worlds);
-							int tes = ASMHookTerminator.currentTEs.get();
-							maxTEs[currentPos] = Math.max(maxTEs[currentPos], tes);
-							int entities = ASMHookTerminator.currentEnts.get();
+									worldTicks);
+							int entities = ASMHookTerminator.entityExecutionStack.size();
 							maxEntities[currentPos] = Math.max(maxEntities[currentPos],
 									entities);
-							int envs = ASMHookTerminator.currentEnvs.get();
-							maxEnvs[currentPos] = Math.max(maxEnvs[currentPos], envs);
-							total = worlds+tes+entities+envs;
+							total = worldTicks+entities;
 							maxThreads[currentPos] = Math.max(maxThreads[currentPos], total);
 									
 						}

--- a/src/main/java/org/jmt/mcmt/config/GeneralConfig.java
+++ b/src/main/java/org/jmt/mcmt/config/GeneralConfig.java
@@ -77,6 +77,8 @@ public class GeneralConfig {
 	public static boolean opsTracing;
 	public static int logcap;
 	
+	public static boolean continueAfterStuckTick;
+	
 	//Forge stuff
 	public static final GeneralConfigTemplate GENERAL;
 	public static final ForgeConfigSpec GENERAL_SPEC;
@@ -150,6 +152,8 @@ public class GeneralConfig {
 		opsTracing = GENERAL.opsTracing.get();
 		logcap = GENERAL.logcap.get();
 		
+		continueAfterStuckTick = GENERAL.continueAfterStuckTick.get();
+		
 		teWhiteList = ConcurrentHashMap.newKeySet();//new HashSet<Class<?>>();
 		teUnfoundWhiteList = new ArrayList<String>();
 		GENERAL.teWhiteList.get().forEach(str -> {
@@ -197,6 +201,8 @@ public class GeneralConfig {
 		GENERAL.opsTracing.set(opsTracing);
 		GENERAL.logcap.set(logcap);
 		
+		GENERAL.continueAfterStuckTick.set(continueAfterStuckTick);
+		
 		GENERAL.teWhiteList.get().clear();
 		GENERAL.teWhiteList.get().addAll(teUnfoundWhiteList);
 		GENERAL.teWhiteList.get().addAll(teWhiteList.stream().map(clz -> clz.getName()).collect(Collectors.toList()));
@@ -234,6 +240,8 @@ public class GeneralConfig {
 		
 		public final BooleanValue opsTracing;
 		public final IntValue logcap;
+		
+		public final BooleanValue continueAfterStuckTick;
 		
 		public GeneralConfigTemplate(ForgeConfigSpec.Builder builder) {
 			builder.push("general");
@@ -308,7 +316,7 @@ public class GeneralConfig {
 					.comment("Attempts to re-load timed out chunks; Seems to work")
 					.define("enableTimeoutReload", false);
 			timeoutCount = builder
-					.comment("Ammount of workless iterations to wait before declaring a chunk load attempt as timed out\n"
+					.comment("Amount of workless iterations to wait before declaring a chunk load attempt as timed out\n"
 							+"This is in ~100us itterations (plus minus yield time) so timeout >= timeoutCount*100us")
 					.defineInRange("timeoutCount", 5000, 500, 500000);
 			builder.pop();
@@ -323,6 +331,11 @@ public class GeneralConfig {
 			logcap = builder
 					.comment("Maximum time between MCMT presence alerts in 10ms steps")
 					.defineInRange("logcap", 720000, 15000, Integer.MAX_VALUE);
+			builder.pop();
+			builder.push("continueAfterStuckTick");
+			builder.comment("Allows continuation after a stuck tick. "
+					+ "This is HIGHLY unstable, so don't enable it unless you know what you're doing and have backups.");
+			continueAfterStuckTick = builder.define("continueAfterStuckTick", false);
 		}
 
 	}

--- a/src/main/java/org/jmt/mcmt/config/GeneralConfig.java
+++ b/src/main/java/org/jmt/mcmt/config/GeneralConfig.java
@@ -336,6 +336,7 @@ public class GeneralConfig {
 			builder.comment("Allows continuation after a stuck tick. "
 					+ "This is HIGHLY unstable, so don't enable it unless you know what you're doing and have backups.");
 			continueAfterStuckTick = builder.define("continueAfterStuckTick", false);
+			builder.pop();
 		}
 
 	}

--- a/src/main/java/org/jmt/mcmt/paralelised/ConcurrentArrayList.java
+++ b/src/main/java/org/jmt/mcmt/paralelised/ConcurrentArrayList.java
@@ -1,0 +1,458 @@
+package org.jmt.mcmt.paralelised;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.ListIterator;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ * @author Hunter
+ *
+ * @param <E> the type of elements in this list
+ */
+public class ConcurrentArrayList<E> extends ArrayList<E> {
+	private static final long serialVersionUID = -6104897338204207229L;
+	private ReadWriteLock lock = new ReentrantReadWriteLock();
+	
+	public ConcurrentArrayList() {
+		super();
+	}
+	
+	public ConcurrentArrayList(Collection<? extends E> arg0) {
+		super(arg0);
+	}
+	
+	public ConcurrentArrayList(int capacity) {
+		super(capacity);
+	}
+	
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		lock.readLock().lock();
+		try {
+			return super.containsAll(c);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean contains(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.contains(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.equals(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public void forEach(Consumer<? super E> action) {
+		lock.readLock().lock();
+		try {
+			super.forEach(action);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public E get(int index) {
+		lock.readLock().lock();
+		try {
+			return super.get(index);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public int hashCode() {
+		lock.readLock().lock();
+		try {
+			return super.hashCode();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public int indexOf(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.indexOf(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean isEmpty() {
+		return super.isEmpty(); // Immediate return doesn't require a read lock
+	}
+	
+	@Override
+	public int lastIndexOf(Object o) {
+		lock.readLock().lock();
+		try {
+			return super.lastIndexOf(o);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public int size() {
+		lock.readLock().lock();
+		try {
+			return super.size();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public Object[] toArray() {
+		lock.readLock().lock();
+		try {
+			return super.toArray();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public <T> T[] toArray(IntFunction<T[]> generator) {
+		lock.readLock().lock();
+		try {
+			return super.toArray(generator);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public <T> T[] toArray(T[] a) {
+		lock.readLock().lock();
+		try {
+			return super.toArray(a);
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public String toString() {
+		lock.readLock().lock();
+		try {
+			return super.toString();
+		} finally {
+			lock.readLock().unlock();			
+		}
+	}
+	
+	@Override
+	public boolean add(E e) {
+		lock.writeLock().lock();
+		try {
+			return super.add(e);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void add(int index, E element) {
+		lock.writeLock().lock();
+		try {
+			super.add(index, element);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean addAll(Collection<? extends E> c) {
+		lock.writeLock().lock();
+		try {
+			return super.addAll(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean addAll(int index, Collection<? extends E> c) {
+		lock.writeLock().lock();
+		try {
+			return super.addAll(index, c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void clear() {
+		lock.writeLock().lock();
+		try {
+			super.clear();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public Object clone() {
+		lock.readLock().lock();
+		try {
+			return super.clone();
+		} finally {
+			lock.readLock().unlock();
+		}
+	}
+	
+	@Override
+	public void ensureCapacity(int minCapacity) {
+		lock.writeLock().lock();
+		try {
+			super.ensureCapacity(minCapacity);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public E remove(int index) {
+		lock.writeLock().lock();
+		try {
+			return super.remove(index);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void trimToSize() {
+		lock.writeLock().lock();
+		try {
+			super.trimToSize();
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean remove(Object o) {
+		lock.writeLock().lock();
+		try {
+			return super.remove(o);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		lock.writeLock().lock();
+		try {
+			return super.removeAll(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean removeIf(Predicate<? super E> filter) {
+		lock.writeLock().lock();
+		try {
+			return super.removeIf(filter);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	protected void removeRange(int fromIndex, int toIndex) {
+		lock.writeLock().lock();
+		try {
+			super.removeRange(fromIndex, toIndex);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void replaceAll(UnaryOperator<E> operator) {
+		lock.writeLock().lock();
+		try {
+			super.replaceAll(operator);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		lock.writeLock().lock();
+		try {
+			return super.retainAll(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public E set(int index, E element) {
+		lock.writeLock().lock();
+		try {
+			return super.set(index, element);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public void sort(Comparator<? super E> c) {
+		lock.writeLock().lock();
+		try {
+			super.sort(c);
+		} finally {
+			lock.writeLock().unlock();
+		}
+	}
+	
+	@Override
+	public Iterator<E> iterator() {
+		return new CopiedIterator(this);
+	}
+	
+	@Override
+	public ListIterator<E> listIterator() {
+		return new CopiedListIterator(this);
+	}
+	
+	@Override
+	public ListIterator<E> listIterator(int index) {
+		return new CopiedListIterator(this, index);
+	}
+	
+	/**
+	 * Creates a snapshot of the Collection to iterate over. Useful for concurrent access to the entirety of a Collection.
+	 * <p>
+	 * Caveats: <p>
+	 * Creates a copy of the Collection as an array, so uses more memory
+	 * (<a href="https://www.baeldung.com/java-size-of-object#1-objects-references-and-wrapper-classes">but not 100% more, just for object references</a>)
+	 * <p>
+	 * Any changes to the objects in the Iterator will be reflected in the originating Collection.
+	 *   
+	 * @author hunterh 
+	 */
+	private class CopiedIterator implements Iterator<E> {
+		private Object[] internal;
+		private int pointer;
+		
+		public CopiedIterator(Collection<? extends E> c) {
+			this.pointer = 0;
+			this.internal = c.toArray();
+		}
+
+		@Override
+		public boolean hasNext() {
+			return internal.length > pointer;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public E next() {
+			return (E) this.internal[this.pointer++];
+		}
+	}
+	
+	/**
+	 * Creates a snapshot of the Collection to iterate over. Useful for concurrent access to the entirety of a Collection.
+	 * <p>
+	 * Caveats: <p>
+	 * Creates a copy of the Collection as a {@link ConcurrentArrayList}, so uses more memory
+	 * (<a href="https://www.baeldung.com/java-size-of-object#1-objects-references-and-wrapper-classes">but not 100% more, just for object references</a>)
+	 * <p>
+	 * Any changes to the objects in the Iterator will be reflected in the originating Collection.
+	 *   
+	 * @author hunterh 
+	 */
+	private class CopiedListIterator implements ListIterator<E> {
+		private ConcurrentArrayList<E> backing;
+		private int pointer;
+		
+		public CopiedListIterator(Collection<? extends E> data) {
+			backing = new ConcurrentArrayList<>(data);
+			pointer = 0;
+		}
+		
+		public CopiedListIterator(Collection<? extends E> data, int start) {
+			backing = new ConcurrentArrayList<>(data);
+			pointer = start;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return backing.size() > pointer;
+		}
+
+		@Override
+		public E next() {
+			return backing.get(pointer++);
+		}
+
+		@Override
+		public boolean hasPrevious() {
+			return pointer > 0;
+		}
+
+		@Override
+		public E previous() {
+			return backing.get(pointer--);
+		}
+
+		@Override
+		public int nextIndex() {
+			return hasNext() ? pointer + 1 : backing.size();
+		}
+
+		@Override
+		public int previousIndex() {
+			return hasPrevious() ? pointer - 1: -1;
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException("CopiedListIterator does not support remove()");
+		}
+
+		@Override
+		public void set(E e) {
+			throw new UnsupportedOperationException("CopiedListIterator does not support set()");
+		}
+
+		@Override
+		public void add(E e) {
+			throw new UnsupportedOperationException("CopiedListIterator does not support add()");
+		}
+	}
+}

--- a/src/main/java/org/jmt/mcmt/paralelised/GatedLock.java
+++ b/src/main/java/org/jmt/mcmt/paralelised/GatedLock.java
@@ -1,0 +1,29 @@
+package org.jmt.mcmt.paralelised;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class GatedLock {
+	private ConcurrentHashMap<Object, ReentrantLock> locks = new ConcurrentHashMap<>();
+	
+	public boolean isLocked(Object on) {
+		if (!locks.containsKey(on)) return false;
+		return locks.get(on).isLocked();
+	}
+	
+	public void lockOn(Object on) {
+		locks.computeIfAbsent(on, (x) -> new ReentrantLock()).lock();
+		return;
+	}
+	
+	public void waitForUnlock(Object on) {
+		if (!this.isLocked(on)) return;
+		locks.computeIfAbsent(on, (x) -> new ReentrantLock()).lock();
+		locks.get(on).unlock();
+	}
+	
+	public void unlock(Object on) {
+		if (!this.locks.contains(on)) return;
+		locks.get(on).unlock();
+	}
+}

--- a/src/main/java/org/jmt/mcmt/paralelised/TickTask.java
+++ b/src/main/java/org/jmt/mcmt/paralelised/TickTask.java
@@ -1,0 +1,21 @@
+package org.jmt.mcmt.paralelised;
+
+import java.util.concurrent.CompletableFuture;
+
+public class TickTask {
+	private String name;
+	private CompletableFuture<Void> future;
+	
+	public TickTask(String name, CompletableFuture<Void> future) {
+		this.name = name;
+		this.future = future;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public CompletableFuture<Void> getFuture() {
+		return future;
+	}
+}

--- a/src/main/java/org/jmt/mcmt/serdes/filter/AutoFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/AutoFilter.java
@@ -2,6 +2,7 @@ package org.jmt.mcmt.serdes.filter;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 import org.jmt.mcmt.serdes.ISerDesHookType;
 import org.jmt.mcmt.serdes.SerDesRegistry;
@@ -34,8 +35,9 @@ public class AutoFilter implements ISerDesFilter {
 	}
 	
 	@Override
-	public void serialise(Runnable task, Object obj, BlockPos bp, World w, ISerDesHookType hookType) {
-		pool.serialise(task, obj, bp, w, null);
+	public void serialise(Runnable task, Object obj, BlockPos bp, World w, 
+			Consumer<Runnable> multi, ISerDesHookType hookType) {
+		pool.serialise(task, obj, bp, w, multi, null);
 	}
 
 	@Override

--- a/src/main/java/org/jmt/mcmt/serdes/filter/GenericConfigFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/GenericConfigFilter.java
@@ -72,12 +72,12 @@ public class GenericConfigFilter implements ISerDesFilter {
 	}
 	
 	@Override
-	public Set<Class<?>> getWhitelist() {
+	public Set<Class<?>> getAlwaysAsync() {
 		return whitelist;
 	}
 	
 	@Override
-	public Set<Class<?>> getTargets() {
+	public Set<Class<?>> getFiltered() {
 		return blacklist;
 	}
 	
@@ -85,12 +85,12 @@ public class GenericConfigFilter implements ISerDesFilter {
 	public ClassMode getModeOnline(Class<?> c) {
 		if (regexBlacklist != null) {
 			if (regexBlacklist.matcher(c.getName()).find()) {
-				return ClassMode.CHUNKLOCK;
+				return ClassMode.FILTERED;
 			}
 		}
 		if (regexWhitelist != null) {
 			if (regexWhitelist.matcher(c.getName()).find()) {
-				return ClassMode.WHITELIST;
+				return ClassMode.ALWAYS_ASYNC;
 			}
 		}
 		return ClassMode.UNKNOWN;

--- a/src/main/java/org/jmt/mcmt/serdes/filter/GenericConfigFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/GenericConfigFilter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import org.jmt.mcmt.config.SerDesConfig;
@@ -84,7 +85,7 @@ public class GenericConfigFilter implements ISerDesFilter {
 	public ClassMode getModeOnline(Class<?> c) {
 		if (regexBlacklist != null) {
 			if (regexBlacklist.matcher(c.getName()).find()) {
-				return ClassMode.BLACKLIST;
+				return ClassMode.CHUNKLOCK;
 			}
 		}
 		if (regexWhitelist != null) {
@@ -96,8 +97,9 @@ public class GenericConfigFilter implements ISerDesFilter {
 	}
 	
 	@Override
-	public void serialise(Runnable task, Object obj, BlockPos bp, World w, ISerDesHookType hookType) {
-		primePool.serialise(task, hookType, bp, w, primeOpts);
+	public void serialise(Runnable task, Object obj, BlockPos bp, World w,
+			Consumer<Runnable> executeMultithreaded, ISerDesHookType hookType) {
+		primePool.serialise(task, hookType, bp, w, executeMultithreaded, primeOpts);
 	}
 
 }

--- a/src/main/java/org/jmt/mcmt/serdes/filter/ISerDesFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/ISerDesFilter.java
@@ -1,6 +1,7 @@
 package org.jmt.mcmt.serdes.filter;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -12,7 +13,8 @@ import net.minecraft.world.World;
 
 public interface ISerDesFilter {
 
-	public void serialise(Runnable task, Object obj, BlockPos bp, World w, ISerDesHookType hookType);
+	public void serialise(Runnable task, Object obj, BlockPos bp, World w, 
+			Consumer<Runnable> executeMultithreaded, ISerDesHookType hookType);
 	
 	@Nullable
 	public default Set<Class<?>> getTargets() {
@@ -35,7 +37,7 @@ public interface ISerDesFilter {
 	}
 	
 	public static enum ClassMode {
-		BLACKLIST,
+		CHUNKLOCK,
 		WHITELIST,
 		UNKNOWN;
 	}

--- a/src/main/java/org/jmt/mcmt/serdes/filter/ISerDesFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/ISerDesFilter.java
@@ -17,13 +17,13 @@ public interface ISerDesFilter {
 			Consumer<Runnable> executeMultithreaded, ISerDesHookType hookType);
 	
 	@Nullable
-	public default Set<Class<?>> getTargets() {
+	public default Set<Class<?>> getFiltered() {
 		return null;
 	}
 	
 	/**
 	 * Perform initialisation; this may include optimisation steps like looking up 
-	 * pools pre-emptively, generating pook configs, etc.
+	 * pools pre-emptively, generating pool configs, etc.
 	 * 
 	 * As such it is invoked after pools are initialised
 	 */
@@ -32,13 +32,13 @@ public interface ISerDesFilter {
 	}
 	
 	@Nullable
-	public default Set<Class<?>> getWhitelist() {
+	public default Set<Class<?>> getAlwaysAsync() {
 		return null;
 	}
 	
 	public static enum ClassMode {
-		CHUNKLOCK,
-		WHITELIST,
+		FILTERED,
+		ALWAYS_ASYNC,
 		UNKNOWN;
 	}
 	

--- a/src/main/java/org/jmt/mcmt/serdes/filter/LegacyFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/LegacyFilter.java
@@ -3,6 +3,7 @@ package org.jmt.mcmt.serdes.filter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.jmt.mcmt.config.GeneralConfig;
 import org.jmt.mcmt.serdes.ISerDesHookType;
@@ -28,8 +29,9 @@ public class LegacyFilter implements ISerDesFilter {
 	}
 	
 	@Override
-	public void serialise(Runnable task, Object obj, BlockPos bp, World w, ISerDesHookType hookType) {
-		clp.serialise(task, obj, bp, w, config);
+	public void serialise(Runnable task, Object obj, BlockPos bp, World w, 
+			Consumer<Runnable> executeMultithreaded, ISerDesHookType hookType) {
+		clp.serialise(task, obj, bp, w, executeMultithreaded, config);
 	}
 	
 	@Override

--- a/src/main/java/org/jmt/mcmt/serdes/filter/LegacyFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/LegacyFilter.java
@@ -35,12 +35,12 @@ public class LegacyFilter implements ISerDesFilter {
 	}
 	
 	@Override
-	public Set<Class<?>> getTargets() {
+	public Set<Class<?>> getFiltered() {
 		return GeneralConfig.teBlackList;
 	}
 	
 	@Override
-	public Set<Class<?>> getWhitelist() {
+	public Set<Class<?>> getAlwaysAsync() {
 		return GeneralConfig.teWhiteList;
 	}
 

--- a/src/main/java/org/jmt/mcmt/serdes/filter/PistonFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/PistonFilter.java
@@ -37,7 +37,7 @@ public class PistonFilter implements ISerDesFilter {
 	}
 	
 	@Override
-	public Set<Class<?>> getTargets() {
+	public Set<Class<?>> getFiltered() {
 		Set<Class<?>> out = new HashSet<Class<?>>();
 		out.add(PistonTileEntity.class);
 		return out;

--- a/src/main/java/org/jmt/mcmt/serdes/filter/PistonFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/PistonFilter.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.jmt.mcmt.serdes.ISerDesHookType;
 import org.jmt.mcmt.serdes.SerDesRegistry;
@@ -30,8 +31,9 @@ public class PistonFilter implements ISerDesFilter {
 	}
 	
 	@Override
-	public void serialise(Runnable task, Object obj, BlockPos bp, World w, ISerDesHookType hookType) {
-		clp.serialise(task, obj, bp, w, config);
+	public void serialise(Runnable task, Object obj, BlockPos bp, World w, 
+			Consumer<Runnable> executeMultithreaded, ISerDesHookType hookType) {
+		clp.serialise(task, obj, bp, w, executeMultithreaded, config);
 	}
 	
 	@Override

--- a/src/main/java/org/jmt/mcmt/serdes/filter/VanillaFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/VanillaFilter.java
@@ -1,5 +1,7 @@
 package org.jmt.mcmt.serdes.filter;
 
+import java.util.function.Consumer;
+
 import org.jmt.mcmt.serdes.ISerDesHookType;
 
 import net.minecraft.tileentity.PistonTileEntity;
@@ -9,8 +11,9 @@ import net.minecraft.world.World;
 public class VanillaFilter implements ISerDesFilter {
 
 	@Override
-	public void serialise(Runnable task, Object obj, BlockPos bp, World w, ISerDesHookType hookType) {
-		task.run();
+	public void serialise(Runnable task, Object obj, BlockPos bp, World w, 
+			Consumer<Runnable> executeMultithreaded, ISerDesHookType hookType) {
+		executeMultithreaded.accept(task);
 	}
 
 	@Override

--- a/src/main/java/org/jmt/mcmt/serdes/filter/VanillaFilter.java
+++ b/src/main/java/org/jmt/mcmt/serdes/filter/VanillaFilter.java
@@ -19,7 +19,7 @@ public class VanillaFilter implements ISerDesFilter {
 	@Override
 	public ClassMode getModeOnline(Class<?> c) {
 		if (c.getName().startsWith("net.minecraft") && !c.equals(PistonTileEntity.class)) {
-			return ClassMode.WHITELIST;
+			return ClassMode.ALWAYS_ASYNC;
 		}
 		return ClassMode.UNKNOWN;
 	}

--- a/src/main/java/org/jmt/mcmt/serdes/pools/ChunkLockPool.java
+++ b/src/main/java/org/jmt/mcmt/serdes/pools/ChunkLockPool.java
@@ -1,5 +1,7 @@
 package org.jmt.mcmt.serdes.pools;
 
+import java.util.function.Consumer;
+
 import javax.annotation.Nullable;
 
 import org.jmt.mcmt.paralelised.ChunkLock;
@@ -22,14 +24,15 @@ public class ChunkLockPool implements ISerDesPool {
 	}
 	
 	@Override
-	public void serialise(Runnable task, Object o, BlockPos bp, World w, @Nullable ISerDesOptions options) {
+	public void serialise(Runnable task, Object o, BlockPos bp, World w, 
+			Consumer<Runnable> executeMultithreaded, @Nullable ISerDesOptions options) {
 		int range = 1;
 		if (options instanceof CLPOptions) {
 			range = ((CLPOptions) options).getRange();
 		}
 		long[] locks = cl.lock(bp, range);
 		try {
-			task.run();
+			executeMultithreaded.accept(task);
 		} finally {
 			cl.unlock(locks);
 		}

--- a/src/main/java/org/jmt/mcmt/serdes/pools/ChunkLockPool.java
+++ b/src/main/java/org/jmt/mcmt/serdes/pools/ChunkLockPool.java
@@ -5,7 +5,9 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import org.jmt.mcmt.paralelised.ChunkLock;
+import org.jmt.mcmt.serdes.filter.AutoFilter;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -13,28 +15,32 @@ public class ChunkLockPool implements ISerDesPool {
 
 	public class CLPOptions implements ISerDesOptions {
 		int range;
-		
+
 		public int getRange() { return range; };
 	}
-	
+
 	ChunkLock cl = new ChunkLock();
-	
+
 	public ChunkLockPool() {
-		
+
 	}
-	
+
 	@Override
 	public void serialise(Runnable task, Object o, BlockPos bp, World w, 
 			Consumer<Runnable> executeMultithreaded, @Nullable ISerDesOptions options) {
-		int range = 1;
-		if (options instanceof CLPOptions) {
-			range = ((CLPOptions) options).getRange();
-		}
-		long[] locks = cl.lock(bp, range);
-		try {
-			executeMultithreaded.accept(task);
-		} finally {
-			cl.unlock(locks);
-		}
+		executeMultithreaded.accept(() -> {
+			int range = 1;
+			if (options instanceof CLPOptions) {
+				range = ((CLPOptions) options).getRange();
+			}
+			long[] locks = cl.lock(bp, range);
+			try {
+				task.run();
+			} catch (Exception e) {
+				if (o instanceof Entity) AutoFilter.singleton().addClassToBlacklist(o.getClass());
+			} finally {
+				cl.unlock(locks);
+			}
+		});
 	}
 }

--- a/src/main/java/org/jmt/mcmt/serdes/pools/ISerDesPool.java
+++ b/src/main/java/org/jmt/mcmt/serdes/pools/ISerDesPool.java
@@ -1,6 +1,7 @@
 package org.jmt.mcmt.serdes.pools;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
@@ -11,7 +12,8 @@ public interface ISerDesPool {
 
 	public interface ISerDesOptions {}
 	
-	public void serialise(Runnable task, Object o, BlockPos bp, World w, @Nullable ISerDesOptions options);
+	public void serialise(Runnable task, Object o, BlockPos bp, World w, 
+			Consumer<Runnable> executeMultithreaded, @Nullable ISerDesOptions options);
 	
 	public default ISerDesOptions compileOptions(Map<String, Object> config) {
 		return null;

--- a/src/main/java/org/jmt/mcmt/serdes/pools/MainThreadExecutionPool.java
+++ b/src/main/java/org/jmt/mcmt/serdes/pools/MainThreadExecutionPool.java
@@ -1,0 +1,15 @@
+package org.jmt.mcmt.serdes.pools;
+
+import java.util.function.Consumer;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class MainThreadExecutionPool implements ISerDesPool {
+
+	@Override
+	public void serialise(Runnable task, Object o, BlockPos bp, World w, Consumer<Runnable> executeMultithreaded,
+			ISerDesOptions options) {
+		task.run();
+	}
+}

--- a/src/main/java/org/jmt/mcmt/serdes/pools/SingleExecutionPool.java
+++ b/src/main/java/org/jmt/mcmt/serdes/pools/SingleExecutionPool.java
@@ -2,24 +2,29 @@ package org.jmt.mcmt.serdes.pools;
 
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+/**
+ * Run on main thread.
+ */
 public class SingleExecutionPool implements ISerDesPool {
 
 	private Lock l = new ReentrantLock();
-	
+
 	@Override
-	public void serialise(Runnable task, Object o, BlockPos bp, World w, @Nullable ISerDesOptions options) {
+	public void serialise(Runnable task, Object o, BlockPos bp, World w,
+			Consumer<Runnable> executeMultithreaded, @Nullable ISerDesOptions options) {
 		try {
 			l.lock();
-			task.run();
+			task.run();;
 		} finally {
 			l.unlock();
 		}
 	}
-	
+
 }

--- a/src/main/java/org/jmt/mcmt/serdes/pools/SingleExecutionPool.java
+++ b/src/main/java/org/jmt/mcmt/serdes/pools/SingleExecutionPool.java
@@ -21,7 +21,7 @@ public class SingleExecutionPool implements ISerDesPool {
 			Consumer<Runnable> executeMultithreaded, @Nullable ISerDesOptions options) {
 		try {
 			l.lock();
-			task.run();;
+			task.run();
 		} finally {
 			l.unlock();
 		}

--- a/src/main/resources/trans/debug/SCPDriveDebug.js
+++ b/src/main/resources/trans/debug/SCPDriveDebug.js
@@ -53,7 +53,7 @@ function initializeCoreMod() {
         		il.add(new VarInsnNode(opcodes.ALOAD, 8));
         		il.add(new VarInsnNode(opcodes.LLOAD, 6));
         		il.add(new MethodInsnNode(opcodes.INVOKESTATIC, 
-        				"org/jmt/mcmt/asmdest/DebugHookTerminator", "chunkLoadDrive",
+        				"org/jmt/mcmt/asmdest/ChunkRepairHookTerminator", "chunkLoadDrive",
         				"(Lnet/minecraft/world/server/ServerChunkProvider$ChunkExecutor;Ljava/util/function/BooleanSupplier;Lnet/minecraft/world/server/ServerChunkProvider;Ljava/util/concurrent/CompletableFuture;J)V"        				,false));
         		il.add(new JumpInsnNode(opcodes.GOTO, skipTarget));
         		
@@ -114,7 +114,7 @@ function initializeCoreMod() {
         		
         		var il = new InsnList();
         		il.add(new MethodInsnNode(opcodes.INVOKESTATIC, 
-        				"org/jmt/mcmt/asmdest/DebugHookTerminator", "isBypassLoadTarget",
+        				"org/jmt/mcmt/asmdest/ChunkRepairHookTerminator", "isBypassLoadTarget",
         				"()Z"
         				,false));
         		il.add(new JumpInsnNode(opcodes.IFNE, labelTgt));
@@ -175,7 +175,7 @@ function initializeCoreMod() {
         		var il = new InsnList();
 				//il.add(new InsnNode(opcodes.DUP));
         		//il.add(new MethodInsnNode(opcodes.INVOKESTATIC, 
-        		//		"org/jmt/mcmt/asmdest/DebugHookTerminator", "checkNull",
+        		//		"org/jmt/mcmt/asmdest/ChunkRepairHookTerminator", "checkNull",
         		//		"(Ljava/lang/Object;)V", 
 				//		false));
         		

--- a/src/syncfu/java/org/jmt/mcmt/modlauncher/DevModeEnabler.java
+++ b/src/syncfu/java/org/jmt/mcmt/modlauncher/DevModeEnabler.java
@@ -24,6 +24,7 @@ public class DevModeEnabler implements ITransformer<ClassNode> {
 
 	
 	private static final Logger LOGGER = LogManager.getLogger();
+	@SuppressWarnings("unused")
 	private static final Marker M_LOCATOR = MarkerManager.getMarker("LOCATE");
 	private boolean isActive = true;
 	

--- a/src/syncfu/java/org/jmt/mcmt/modlauncher/FastUtilTransformerService.java
+++ b/src/syncfu/java/org/jmt/mcmt/modlauncher/FastUtilTransformerService.java
@@ -6,7 +6,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;


### PR DESCRIPTION
Completely re-did how ticks are synchronized:

- Instead of every tick task being either totally asynchronous or asynchronous with a chunk lock, tick tasks are sorted into World & Entity groups. World tick tasks are always completed before async Entity tasks. Both need to be complete before the next tick can begin.
- Instances of ISerDesPool don't automatically assume asynchronicity. Instead, the default behavior is to run synchronously on the main thread with the ability to multithread passed into the `serialise` function.
- Changed `WHITELIST` and `BLACKLIST` to `ALWAYS_ASYNC` and `FILTERED` internally. This makes more sense for filters that support more than one type of operation.
- Improved awareness of what's being run. If a tick task gets stuck for more than a second (20 ticks worth of time), the game logs it to console.
  - Added an option to automatically continue after 1 second. This makes things very unstable, but could help diagnose issues.
- Added a synchronized ArrayList